### PR TITLE
Clarify "viewer"

### DIFF
--- a/content/introduction/get-started-bottom.md
+++ b/content/introduction/get-started-bottom.md
@@ -51,7 +51,7 @@ Relay.injectNetworkLayer(
 
 Again, make sure to copy your GraphQL endpoint from above to `package.json` and `index.js`.
 
-* All queries in Relay are wrapped by the so called `viewer` object. We can define it once and use it whenever we want to make a query:
+* Many queries in Relay are wrapped by the so called `viewer` object. We can define it once and use it whenever we want to make a query against the viewer field:
 
 ```javascript
 const ViewerQueries = { viewer: () => Relay.QL`query { viewer }` }


### PR DESCRIPTION
We've seen a fair number of people mistakenly put *all* of their fields under `viewer`, even when they don't need to. This leads to patterns where the route has just `viewer`, and then the container has something like `fragment on Viewer { node(id: $id) }` - super confusing and totally unnecessary, since you can do `query { node(id: $id) }`.