### PR TITLE
Remove `withRouter`

### DIFF
--- a/content/queries/containers-fragments.md
+++ b/content/queries/containers-fragments.md
@@ -15,7 +15,7 @@ To expose data to your React component we can use the method `Relay.createContai
 
 ```javascript
 export default Relay.createContainer(
-  withRouter(ListPage),
+  ListPage,
   {
     fragments: {
       viewer: () => Relay.QL`
@@ -45,7 +45,7 @@ Let's have another look at the Relay container we just built:
 
 ```javascript
 export default Relay.createContainer(
-  withRouter(ListPage),
+  ListPage,
   {
     fragments: {
       viewer: () => Relay.QL`


### PR DESCRIPTION
What is `withRouter`? In general it's helpful to introduce as few new concepts at a time. I already know how Relay works, and I was immediately confused by `withRouter`, so I imagine people reading will be too.