### PR TITLE
fix prepareVariables; return object

### DIFF
--- a/content/queries/variables.md
+++ b/content/queries/variables.md
@@ -91,9 +91,9 @@ export default Relay.createContainer(
     initialVariables: {
       sortOrder: 'id_DESC'
     },
-    prepareVariables: (prevVariables) => {
+    prepareVariables: (prevVariables) => ({
       amount: prevVariables.sortOrder.startsWith('id') ? 1000 : 100000
-    },
+    }),
     fragments: {
       viewer: () => Relay.QL`
         fragment on Viewer {


### PR DESCRIPTION
This is syntactically valid, but it does not work as one would likely expect – there is no return value

```
foo => { amount: bar }
```

I think the intention was to return an object with an `amount` property

```
foo => ({ amount: bar })
```