### PR TITLE
add edgeName to getConfigs of NODE_DELETE

### DIFF
--- a/content/mutations/mutation-types.md
+++ b/content/mutations/mutation-types.md
@@ -66,6 +66,7 @@ getConfigs () {
     parentName: 'viewer',
     parentID: this.props.viewerId,
     connectionName: 'pokemon',
+    edgeName: 'edge',
     deletedIDFieldName: 'deletedId',
   }]
 }


### PR DESCRIPTION
It seems to be an edgeName in getConfig of NODE_DELETE or it's unnecessary mentioning in the first string where it mentioned.