### PR TITLE
Change prop model to pokemon in getOptimisticResponse of UpdatePokemo…

### DIFF
--- a/src/mutations/UpdatePokemonMutation.ts
+++ b/src/mutations/UpdatePokemonMutation.ts
@@ -40,7 +40,7 @@ export default class UpdatePokemonMutation extends Relay.Mutation<Props, {}> {
 
   getOptimisticResponse () {
     return {
-      model: {
+      pokemon: {
         id: this.props.pokemonId,
         name: this.props.name,
         url: this.props.url,


### PR DESCRIPTION
I'm not understanding deeply mutation under the hood so far, but when we get object with prop model I suppose it wouldn't update pokemon with optimistic update.