### PR TITLE
add deprecation notice in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Source code for [learnrelay.org](https://learnrelay.org)
 
+:exclamation: **Moved to https://www.howtographql.com/react-relay/0-introduction/** 
+
+
 ## Contribution
 
 If you have a suggestion on how to improve Learn Relay please either [open an issue](https://github.com/learnrelay/learnrelay/issues/new) or create a pull request by changing the source files in [`content`](https://github.com/learnrelay/learnrelay/tree/master/content).


### PR DESCRIPTION
I was confused after redirect to howtographql.com, because its not easy to find the Relay tutorial there. 

For several days I just thought, there are only the combinations in the middle of the page (apollo, etc).
Also the top right menu is not helpful :-)

Maybe this note could help someone.
